### PR TITLE
Change type to kill_type on line 197

### DIFF
--- a/game_modes/buildandsplat.py
+++ b/game_modes/buildandsplat.py
@@ -194,7 +194,7 @@ def apply_script(protocol, connection, config):
             if not local:
                 self.protocol.send_contained(change_weapon, save = True)
                 if not no_kill:
-                    self.kill(type = CLASS_CHANGE_KILL)
+                    self.kill(kill_type = CLASS_CHANGE_KILL)
 
         def _on_fire(self):
             if self.team is not None and self.world_object is not None:


### PR DESCRIPTION
Attempting to change weapons in-game leads to an error which can be solved by simply changing the keyword: 

```
2020-02-26T15:51:45+0000 [stderr#error] Traceback (most recent call last):
2020-02-26T15:51:45+0000 [stderr#error]   File "/usr/lib/python3.8/site-packages/pyspades/protocol.py", line 171, in update
2020-02-26T15:51:45+0000 [stderr#error]     self.data_received(peer, event.packet)
2020-02-26T15:51:45+0000 [stderr#error]   File "/usr/lib/python3.8/site-packages/piqueserver/server.py", line 829, in data_received
2020-02-26T15:51:45+0000 [stderr#error]     ServerProtocol.data_received(self, peer, packet)
2020-02-26T15:51:45+0000 [stderr#error]   File "/usr/lib/python3.8/site-packages/pyspades/protocol.py", line 123, in data_received
2020-02-26T15:51:45+0000 [stderr#error]     connection.loader_received(packet)
2020-02-26T15:51:45+0000 [stderr#error]   File "/usr/lib/python3.8/site-packages/pyspades/player.py", line 153, in loader_received
2020-02-26T15:51:45+0000 [stderr#error]     call_packet_handler(self, loader)
2020-02-26T15:51:45+0000 [stderr#error]   File "pyspades/packet.pyx", line 131, in pyspades.packet.call_packet_handler
2020-02-26T15:51:45+0000 [stderr#error]   File "/usr/lib/python3.8/site-packages/pyspades/player.py", line 657, in on_weapon_change_recieved
2020-02-26T15:51:45+0000 [stderr#error]     self.set_weapon(self.weapon)
2020-02-26T15:51:45+0000 [stderr#error]   File "/home/ag/.config/piqueserver/game_modes/buildandsplat.py", line 197, in set_weapon
2020-02-26T15:51:45+0000 [stderr#error]     self.kill(type = CLASS_CHANGE_KILL)
2020-02-26T15:51:45+0000 [stderr#error] TypeError: kill() got an unexpected keyword argument 'type'
```